### PR TITLE
Enable unit back

### DIFF
--- a/sql/unit_disable_existing.sql
+++ b/sql/unit_disable_existing.sql
@@ -16,6 +16,14 @@
 
 # We need the BZ product id for the unit
 	SET @product_id = '%s';
+
+# We need the BZ user id of the user who is making the change
+    SET @bz_user_id = 'enter_the_bz_user_id_of_the_user_who_initiate_the_change';
+
+# We need the environment you are in
+#	- 1 is for DEV/Staging
+#	- 2 is PROD
+#	- 3 is Demo/Local installation
 	SET @environment = %d;
 
 # We also need to know the date when the unit was disabled in the MEFE

--- a/sql/unit_enable_existing.sql
+++ b/sql/unit_enable_existing.sql
@@ -16,6 +16,14 @@
 
 # We need the BZ product id for the unit
 	SET @product_id = '%s';
+
+# We need the BZ user id of the user who is making the change
+    SET @bz_user_id = 'enter_the_bz_user_id_of_the_user_who_initiate_the_change';
+
+# We need the environment you are in
+#	- 1 is for DEV/Staging
+#	- 2 is PROD
+#	- 3 is Demo/Local installation
 	SET @environment = %d;
 
 # We also need to know the date when the unit was disabled in the MEFE

--- a/sql/unit_enable_existing.sql
+++ b/sql/unit_enable_existing.sql
@@ -1,0 +1,34 @@
+# For any question about this script, ask Franck
+#
+# Pre-requisite:
+#	- The unit must already exists in the BZ table
+#
+# This script will
+#	- Enable the unit
+#	- Log what it does in the BZ database
+#	- Exit with no error if everything went as expected
+#
+#################################################################
+#
+# UPDATE THE BELOW VARIABLES ACCORDING TO YOUR NEEDS
+#
+#################################################################
+
+# We need the BZ product id for the unit
+	SET @product_id = '%s';
+	SET @environment = %d;
+
+# We also need to know the date when the unit was disabled in the MEFE
+	SET @active_when = NOW();
+
+#
+########################################################################
+#
+# ALL THE VARIABLES WE NEED HAVE BEEN DEFINED, WE CAN RUN THE SCRIPT
+#
+########################################################################
+
+# We have everything, we can now call the procedure which disables a unit
+	CALL `unit_enable_existing`;
+
+


### PR DESCRIPTION
This fixes issues #5 and #6 

@kaihendry the change I introduced means that the API to disable unit now need to include 1 more parameter: the Bz_user_id of the user who is making the change to the unit.